### PR TITLE
VALARM required description

### DIFF
--- a/misc/events.ts
+++ b/misc/events.ts
@@ -31,7 +31,13 @@ export const generateICS = (eventData: Event[]) => {
         location: constants.address,
         url: process.env.NEXT_PUBLIC_BASE_URL,
         organizer: { name: "WayneHacks Team", email: constants.supportEmail },
-        alarms: [{ action: "display", trigger: { minutes: 15, before: true } }],
+        alarms: [
+          {
+            action: "display",
+            description: "Reminder",
+            trigger: { minutes: 15, before: true },
+          },
+        ],
       };
     })
   );


### PR DESCRIPTION
VALARM property in ical alarm requires a description for it to be valid ical format per icalendar validator
![image](https://github.com/ThatZiv/waynehacks/assets/35277113/d549356c-7c36-408a-840a-a76133d30160)
